### PR TITLE
fix: remove goto buttons

### DIFF
--- a/ui/src/app/pages/end-users/end-users.component.html
+++ b/ui/src/app/pages/end-users/end-users.component.html
@@ -52,7 +52,8 @@
         The EOSC Beyond User Space will be soon available
       </div>
       <div class="col-md-6 col-12">
-        <a href="https://marketplace.sandbox.eosc-beyond.eu/" class="btn-more">Go to the Sandbox Marketplace</a>
+        <!---
+        <a href="https://marketplace.sandbox.eosc-beyond.eu/" class="btn-more">Go to the Sandbox Marketplace</a> --->
       </div>
     </div>
   </div>

--- a/ui/src/app/pages/pilot-nodes/pilot-nodes.component.css
+++ b/ui/src/app/pages/pilot-nodes/pilot-nodes.component.css
@@ -1,6 +1,6 @@
 .pilot-nodes {
   background: url(/assets/end-users-bg.jpg) no-repeat 50% 50%;
-  padding: 95px 0 40px;
+  padding: 95px 0 110px;
   background-size: cover;
 }
 

--- a/ui/src/app/pages/pilot-nodes/pilot-nodes.component.css
+++ b/ui/src/app/pages/pilot-nodes/pilot-nodes.component.css
@@ -1,6 +1,6 @@
 .pilot-nodes {
   background: url(/assets/end-users-bg.jpg) no-repeat 50% 50%;
-  padding: 95px 0 110px;
+  padding: 95px 0 40px;
   background-size: cover;
 }
 

--- a/ui/src/app/pages/pilot-nodes/pilot-nodes.component.html
+++ b/ui/src/app/pages/pilot-nodes/pilot-nodes.component.html
@@ -115,15 +115,16 @@
       </div>
 
     </div>
-    <!---
+
         <div class="row">
-          <div class="col-md-6 col-12 special-info">
+          <div class="col-md-12 col-12 special-info">
             Go to the provider portal to try out the integrated Sandbox capabilities for providers.
           </div>
+          <!---
           <div class="col-md-6 col-12">
 
             <a href="https://integration.providers.sandbox.eosc-beyond.eu/home" class="btn-more">Go to the Sandbox Providers Portal</a>
-          </div>
-        </div> -->
+          </div> -->
+        </div>
       </div>
     </section>

--- a/ui/src/app/pages/pilot-nodes/pilot-nodes.component.html
+++ b/ui/src/app/pages/pilot-nodes/pilot-nodes.component.html
@@ -115,14 +115,15 @@
       </div>
 
     </div>
+    <!---
+        <div class="row">
+          <div class="col-md-6 col-12 special-info">
+            Go to the provider portal to try out the integrated Sandbox capabilities for providers.
+          </div>
+          <div class="col-md-6 col-12">
 
-    <div class="row">
-      <div class="col-md-6 col-12 special-info">
-        Go to the provider portal to try out the integrated Sandbox capabilities for providers.
+            <a href="https://integration.providers.sandbox.eosc-beyond.eu/home" class="btn-more">Go to the Sandbox Providers Portal</a>
+          </div>
+        </div> -->
       </div>
-      <div class="col-md-6 col-12">
-        <a href="https://integration.providers.sandbox.eosc-beyond.eu/home" class="btn-more">Go to the Sandbox Providers Portal</a>
-      </div>
-    </div>
-  </div>
-</section>
+    </section>


### PR DESCRIPTION
removed "go to" buttons from homepage:
![image](https://github.com/user-attachments/assets/238d1dd8-44c4-4749-9cf0-55101e2e3826)

![image](https://github.com/user-attachments/assets/ff5b7b96-66b7-4e14-af55-6d10cd0068af)
