### PR TITLE
fix: removed go-to info from homepage

### DIFF
--- a/ui/src/app/pages/pilot-nodes/pilot-nodes.component.css
+++ b/ui/src/app/pages/pilot-nodes/pilot-nodes.component.css
@@ -1,6 +1,6 @@
 .pilot-nodes {
   background: url(/assets/end-users-bg.jpg) no-repeat 50% 50%;
-  padding: 95px 0 110px;
+  padding: 95px 0 40px;
   background-size: cover;
 }
 

--- a/ui/src/app/pages/pilot-nodes/pilot-nodes.component.html
+++ b/ui/src/app/pages/pilot-nodes/pilot-nodes.component.html
@@ -115,16 +115,16 @@
       </div>
 
     </div>
+    <!---
+            <div class="row">
+              <div class="col-md-12 col-12 special-info">
+                Go to the provider portal to try out the integrated Sandbox capabilities for providers.
+              </div>
 
-        <div class="row">
-          <div class="col-md-12 col-12 special-info">
-            Go to the provider portal to try out the integrated Sandbox capabilities for providers.
-          </div>
-          <!---
-          <div class="col-md-6 col-12">
+              <div class="col-md-6 col-12">
 
-            <a href="https://integration.providers.sandbox.eosc-beyond.eu/home" class="btn-more">Go to the Sandbox Providers Portal</a>
-          </div> -->
-        </div>
+                <a href="https://integration.providers.sandbox.eosc-beyond.eu/home" class="btn-more">Go to the Sandbox Providers Portal</a>
+              </div>
+        </div> -->
       </div>
     </section>


### PR DESCRIPTION
removed "go to" text from home page:

![image](https://github.com/user-attachments/assets/15fa80a8-6b61-4a98-96c1-6051346f94b1)
